### PR TITLE
Use Timeout.timeout instead of deprecated method in ruby 2.3.0

### DIFF
--- a/lib/dacpclient/browser.rb
+++ b/lib/dacpclient/browser.rb
@@ -25,7 +25,7 @@ module DACPClient
 
     def browse
       @services = []
-      timeout(5) do
+      Timeout.timeout(5) do
         DNSSD.browse!(TOUCHABLE_SERVICE) do |node|
           resolve(node)
           break unless node.flags.more_coming?


### PR DESCRIPTION
> Object#timeout is now warned as deprecated when called.

from [NEWS for Ruby 2.3.0](http://docs.ruby-lang.org/en/2.3.0/NEWS.html#label-Stdlib+updates+-28outstanding+ones+only-29)
