### PR TITLE
Improve Searching

### DIFF
--- a/bin/dacpclient
+++ b/bin/dacpclient
@@ -142,7 +142,7 @@ class CLIClient < Thor
     playlist_items.each do |playlist|
       printf("%#{num}d. ", count += 1) unless playlist.base_playlist?
 
-      puts "#{playlist.name} (#{playlist.item_id})"
+      puts "#{playlist.name} (#{playlist.count})"
     end
     puts
   end

--- a/bin/dacpclient
+++ b/bin/dacpclient
@@ -115,6 +115,22 @@ class CLIClient < Thor
     show_status
   end
 
+  desc :databases, 'Show the databases'
+  def databases
+    login
+    database_items = @client.databases.items
+    puts 'Databases:'
+    puts '----------'
+    count = 0
+    num = Math.log10(database_items.length).floor + 1
+    database_items.each do |database|
+      printf("%#{num}d. ", count += 1)
+
+      puts "#{database.name} (#{database.item_id})"
+    end
+    puts
+  end
+
   desc :playlists, 'Show the playlists'
   def playlists
     login
@@ -126,7 +142,7 @@ class CLIClient < Thor
     playlist_items.each do |playlist|
       printf("%#{num}d. ", count += 1) unless playlist.base_playlist?
 
-      puts "#{playlist.name} (#{playlist.count})"
+      puts "#{playlist.name} (#{playlist.item_id})"
     end
     puts
   end
@@ -159,6 +175,18 @@ class CLIClient < Thor
       printf("%#{num}d. ", count += 1)
 
       puts "#{album.name} [#{album.album_artist}] (#{album.count} songs)"
+    end
+    puts
+  end
+
+  desc :search, 'Search for a song'
+  def search(query)
+    login
+    songs = @client.search query
+    puts 'Songs:'
+    puts '----------'
+    songs.each do |song|
+      puts "#{song.name} - #{song.artist} - #{song.album}"
     end
     puts
   end

--- a/bin/dacpclient
+++ b/bin/dacpclient
@@ -185,7 +185,11 @@ class CLIClient < Thor
     songs = @client.search query
     puts 'Songs:'
     puts '----------'
+    count = 0
+    num = Math.log10(songs.length).floor + 1
     songs.each do |song|
+      printf("%#{num}d. ", count += 1)
+
       puts "#{song.name} - #{song.artist} - #{song.album}"
     end
     puts

--- a/lib/dacpclient/client.rb
+++ b/lib/dacpclient/client.rb
@@ -271,7 +271,7 @@ module DACPClient
                  com.apple.itunes.movie-info-xml daap.songalbumartist
                  com.apple.itunes.extended-media-kind).join(',')
       url = "databases/#{db.item_id}/containers/#{container.item_id}/items"
-      do_action(url, query: q, type: 'music', sort: 'name', meta: meta,
+      do_action(url, query: q, type: 'music', sort: 'album', meta: meta,
                      :'include-sort-headers' => 1, clean_url: true, model: Songs).items
     end
 

--- a/lib/dacpclient/client.rb
+++ b/lib/dacpclient/client.rb
@@ -237,7 +237,7 @@ module DACPClient
 
     def search(search, type = nil, db = default_db,
                container = default_playlist(default_db))
-      search = URI.escape(search)
+      searches = search.split.map { |q| URI.escape(q) }
       types = {
         title: 'dmap.itemname',
         artist: 'daap.songartist',
@@ -247,11 +247,13 @@ module DACPClient
       }
       queries = []
       type = types.keys if type.nil?
-      Array(type).each do |t|
-        queries << "'#{types[t]}:#{search}'"
+      searches.each do |search|
+        Array(type).each do |t|
+          queries << "'#{types[t]}:#{search}'"
+        end
       end
 
-      q = queries.join(',')
+      q = queries.join(' ')
       q = '(' + q + ')' if queries.length > 1
       meta  = %w(dmap.itemname dmap.itemid com.apple.itunes.has-chapter-data
                  daap.songalbum com.apple.itunes.cloud-id dmap.containeritemid

--- a/lib/dacpclient/models/song.rb
+++ b/lib/dacpclient/models/song.rb
@@ -1,0 +1,9 @@
+module DACPClient
+  class Song < Model
+    dmap_tag :mlit
+    dmap_attribute :item_id, :miid
+    dmap_attribute :name, :minm
+    dmap_attribute :artist, :asar
+    dmap_attribute :album, :asal
+  end
+end

--- a/lib/dacpclient/models/songs.rb
+++ b/lib/dacpclient/models/songs.rb
@@ -1,0 +1,10 @@
+module DACPClient
+  class Songs < Model
+    dmap_tag :apso
+    dmap_attribute :status, :mstt
+    dmap_attribute :update_type, :muty
+    dmap_attribute :container_count, :mtco
+    dmap_attribute :returned_count, :mrco
+    dmap_container :items, :mlcl, DACPClient::Song
+  end
+end


### PR DESCRIPTION
This PR includes some enhancements for searching and also fixes some bugs.

I noticed that the search function was only working for one-word searches, so I used Charles to see what the Remote app was sending for multi-word searches. Here's what the `query` parameter looked like when I searched for "Peace of mind" (I've determined that the extra `media-kind` fields are not necessary):

```
('dmap.itemname:*of*' 'dmap.itemname:*Peace*' ('com.apple.itunes.extended-media-kind:6','com.apple.itunes.extended-media-kind:36','com.apple.itunes.extended-media-kind:64','com.apple.itunes.extended-media-kind:2097158') 'dmap.itemname:*mind*')
```

What I get from this is that iTunes wants search terms to be split up by word and surrounded by wildcard characters. I also noticed that searching amongst multiple fields (title, artist, etc.) wasn't working correctly.

Here's what this PR fixes the query to look like for a search of just song titles:

```
(('dmap.itemname:*Peace*')+('dmap.itemname:*of*')+('dmap.itemname:*Mind*'))
```

And for song title and artists:

```
(('dmap.itemname:*Peace*','daap.songartist:*Peace*')+('dmap.itemname:*of*','daap.songartist:*of*')+('dmap.itemname:*Mind*','daap.songartist:*Mind*'))
```

Note that `,` is used for `OR` and `+` for `AND`.

Another minor change is that I set `title`, `artist` and `album` to be the default fields for a search instead of all of them. This seems like a more sensible default to me. I also added a new `search` command to the example CLI to demonstrate how to use it. And a `databases` command that I found useful in testing.

And finally, I added `Songs ` and `Song` models to better serialize the results of a search call.